### PR TITLE
patch compatibility with nginx 1.20.0

### DIFF
--- a/patches/nginx-1.20.0.patch
+++ b/patches/nginx-1.20.0.patch
@@ -1,0 +1,54 @@
+--- ../nginx-1.20.0/src/http/ngx_http_upstream.c	2021-04-20 15:35:47.000000000 +0200
++++ ./src/http/ngx_http_upstream.c	2021-04-21 10:06:31.244073600 +0200
+@@ -35,8 +35,6 @@
+ static void ngx_http_upstream_wr_check_broken_connection(ngx_http_request_t *r);
+ static void ngx_http_upstream_check_broken_connection(ngx_http_request_t *r,
+     ngx_event_t *ev);
+-static void ngx_http_upstream_connect(ngx_http_request_t *r,
+-    ngx_http_upstream_t *u);
+ static ngx_int_t ngx_http_upstream_reinit(ngx_http_request_t *r,
+     ngx_http_upstream_t *u);
+ static void ngx_http_upstream_send_request(ngx_http_request_t *r,
+@@ -797,10 +795,9 @@
+     u->ssl_name = uscf->host;
+ #endif
+ 
+-    if (uscf->peer.init(r, uscf) != NGX_OK) {
+-        ngx_http_upstream_finalize_request(r, u,
+-                                           NGX_HTTP_INTERNAL_SERVER_ERROR);
+-        return;
++    switch(uscf->peer.init(r, uscf)) {
++        case NGX_OK:   ngx_http_upstream_connect(r, u);
++        case NGX_BUSY: return;
+     }
+ 
+     u->peer.start_time = ngx_current_msec;
+@@ -811,7 +808,7 @@
+         u->peer.tries = u->conf->next_upstream_tries;
+     }
+ 
+-    ngx_http_upstream_connect(r, u);
++    ngx_http_upstream_finalize_request(r, u, NGX_HTTP_INTERNAL_SERVER_ERROR);
+ }
+ 
+ 
+@@ -1506,7 +1503,7 @@
+ }
+ 
+ 
+-static void
++void
+ ngx_http_upstream_connect(ngx_http_request_t *r, ngx_http_upstream_t *u)
+ {
+     ngx_int_t          rc;
+--- ../nginx-1.20.0/src/http/ngx_http_upstream.h	2021-04-20 15:35:47.000000000 +0200
++++ ./src/http/ngx_http_upstream.h	2021-04-21 10:08:08.011750483 +0200
+@@ -415,6 +415,8 @@
+ 
+ ngx_int_t ngx_http_upstream_create(ngx_http_request_t *r);
+ void ngx_http_upstream_init(ngx_http_request_t *r);
++#define NGX_HTTP_UPSTREAM_INIT_BUSY_PATCH_VERSION  1
++void ngx_http_upstream_connect(ngx_http_request_t *r, ngx_http_upstream_t *u);
+ ngx_int_t ngx_http_upstream_non_buffered_filter_init(void *data);
+ ngx_int_t ngx_http_upstream_non_buffered_filter(void *data, ssize_t bytes);
+ ngx_http_upstream_srv_conf_t *ngx_http_upstream_add(ngx_conf_t *cf,


### PR DESCRIPTION
Nginx 1.20.0 breaks the latest patch, because it adds new lines in the .h file (the .c file was not impacted).
Added new patch.

Tested on a server instance, seems to work, at least nginx starts and serves content properly.